### PR TITLE
Fix catchError documentation typo

### DIFF
--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -827,7 +827,7 @@ let tapError: 'a 'e. ('e => unit, t('a, 'e)) => t('a, 'e) =
 
 /**
 Handles an error of types ['e1] from an [IO.t('a, 'e1)] and converts it into a
-new [IO.t('a, 'e1)] value. This is much like [flatMap]/[bind] but works for
+new [IO.t('a, 'e2)] value. This is much like [flatMap]/[bind] but works for
 the error channel of the [IO].
 */
 let rec catchError:


### PR DESCRIPTION
## Summary

Fixes #346: Corrected documentation typo in the `catchError` function.

## Changes

- Fixed documentation comment to show correct output type `'e2` instead of `'e1`
- The function signature shows it converts from `IO.t('a, 'e1)` to `IO.t('a, 'e2)`

## References

- Fixes reazen/relude#346

🤖 Generated with [Claude Code](https://claude.ai/code)